### PR TITLE
[Feature] 온보딩 목표 입력 화면

### DIFF
--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../ui/home/home_view.dart';
+import '../ui/onboarding/views/onboarding_goal_view.dart';
 import 'app_router_interceptor.dart';
 import 'redirect_notifier.dart';
 import 'routes.dart';
@@ -51,7 +52,14 @@ class AppRouter {
           child: HomeView(),
         ),
       ),
-
+      GoRoute(
+        name: Routes.goal.name,
+        path: Routes.goal.path,
+        pageBuilder: (BuildContext context, GoRouterState state) =>
+            const NoTransitionPage<dynamic>(
+          child: OnboardingGoalView(),
+        ),
+      ),
       // Auth
       // GoRoute(
       //   path: Routes.auth.path,

--- a/lib/routes/routes.dart
+++ b/lib/routes/routes.dart
@@ -22,4 +22,10 @@ class Routes {
     name: '/home',
     path: '/home',
   );
+
+  // 온보딩
+  static const RouteInfo goal = RouteInfo(
+    name: '/onboarding/goal',
+    path: '/onboarding/goal',
+  );
 }

--- a/lib/ui/common/widgets/custom_text_field.dart
+++ b/lib/ui/common/widgets/custom_text_field.dart
@@ -23,6 +23,7 @@ class CustomTextField extends StatelessWidget {
   final TextStyle textStyle;
   final TextStyle hintTextStyle;
   final TextInputType textInputType;
+  final Color? fillColor;
 
   const CustomTextField({
     required this.enabledBorderColor,
@@ -38,6 +39,7 @@ class CustomTextField extends StatelessWidget {
     this.textStyle = LuckitTypos.suitR16,
     this.hintTextStyle = LuckitTypos.suitR16,
     this.textAlign = TextAlign.start,
+    this.fillColor,
   });
 
   @override
@@ -61,7 +63,7 @@ class CustomTextField extends StatelessWidget {
             decoration: InputDecoration(
               contentPadding: const EdgeInsets.symmetric(horizontal: 14.0),
               filled: true,
-              fillColor: LuckitColors.gray10,
+              fillColor: fillColor ?? LuckitColors.gray10,
               border: baseBorder,
               enabled: enabled,
               disabledBorder: baseBorder,

--- a/lib/ui/common/widgets/custom_text_field.dart
+++ b/lib/ui/common/widgets/custom_text_field.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+import '../../../theme/luckit_colors.dart';
+import '../../../theme/luckit_typos.dart';
+
+/// border color, text color, text size 등등이 다 달라서
+/// 이 위젯을 베이스로 사용하려고 합니다
+/// mission input field는 본 위젯을 커스텀해서 다시 만들어 뒀습니다
+///
+/// errorText는 수동으로 구현했습니다
+/// 기본 errorText를 쓰려고 보니 height 고정이 어려운 것 같아서요
+class CustomTextField extends StatelessWidget {
+  final double? fieldHeight;
+  final double? fieldWidth;
+
+  final bool enabled;
+  final String? errorText;
+  final String? hintText;
+  final Function(String)? onChanged;
+  final TextAlign textAlign;
+  final Color enabledBorderColor;
+  final Color focusedBorderColor;
+  final TextStyle textStyle;
+  final TextStyle hintTextStyle;
+  final TextInputType textInputType;
+
+  const CustomTextField({
+    required this.enabledBorderColor,
+    required this.focusedBorderColor,
+    required this.textInputType,
+    super.key,
+    this.fieldHeight,
+    this.fieldWidth,
+    this.enabled = true,
+    this.errorText,
+    this.hintText,
+    this.onChanged,
+    this.textStyle = LuckitTypos.suitR16,
+    this.hintTextStyle = LuckitTypos.suitR16,
+    this.textAlign = TextAlign.start,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final OutlineInputBorder baseBorder = OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8.0),
+      borderSide: BorderSide.none,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          height: fieldHeight,
+          width: fieldWidth,
+          child: TextField(
+            textAlign: textAlign,
+            maxLines: 1,
+            onChanged: onChanged,
+            keyboardType: textInputType,
+            decoration: InputDecoration(
+              contentPadding: const EdgeInsets.symmetric(horizontal: 14.0),
+              filled: true,
+              fillColor: LuckitColors.gray10,
+              border: baseBorder,
+              enabled: enabled,
+              disabledBorder: baseBorder,
+              enabledBorder: baseBorder.copyWith(
+                borderSide: BorderSide(
+                  color: enabledBorderColor,
+                ),
+              ),
+              focusedBorder: baseBorder.copyWith(
+                borderSide: BorderSide(
+                  color: focusedBorderColor,
+                ),
+              ),
+              errorBorder: baseBorder.copyWith(
+                borderSide: const BorderSide(
+                  color: LuckitColors.error,
+                ),
+              ),
+              hintText: hintText,
+              hintStyle: hintTextStyle.copyWith()
+            ),
+            cursorWidth: 1.0,
+            cursorColor: LuckitColors.gray80,
+            enableInteractiveSelection: false,
+            style: textStyle,
+          ),
+        ),
+        if (errorText != null)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8.0),
+            child: Text(
+              errorText!,
+              style: const TextStyle(
+                color: LuckitColors.error,
+                fontSize: 10.0,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/ui/common/widgets/mission_text_field.dart
+++ b/lib/ui/common/widgets/mission_text_field.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import '../../../theme/luckit_colors.dart';
+import '../../../theme/luckit_typos.dart';
+import 'custom_text_field.dart';
+
+/// 미션 입력 시 사용하는 text field
+class MissionTextField extends StatelessWidget {
+  final double? fieldWidth;
+  final Function(String)? onChanged;
+  final String? errorText;
+
+  const MissionTextField({
+    super.key,
+    this.fieldWidth,
+    this.onChanged,
+    this.errorText,
+  });
+
+  @override
+  Widget build(BuildContext context) => CustomTextField(
+        fieldHeight: 52.0,
+        fieldWidth: fieldWidth,
+        onChanged: onChanged,
+        hintText: "할 일을 적어주세요",
+        enabledBorderColor: LuckitColors.transparent,
+        focusedBorderColor: LuckitColors.gray40,
+        textInputType: TextInputType.text,
+        textStyle: LuckitTypos.suitR16.copyWith(
+          color: LuckitColors.black,
+        ),
+        hintTextStyle: LuckitTypos.suitR12.copyWith(
+          color: LuckitColors.gray40,
+        ),
+      );
+}

--- a/lib/ui/home/home_view.dart
+++ b/lib/ui/home/home_view.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 // import 'package:go_router/go_router.dart';
 
+import '../../routes/app_router.dart';
+import '../../routes/routes.dart';
 import 'home_state.dart';
 import 'home_view_model.dart';
 
@@ -33,6 +36,10 @@ class _HomeViewState extends ConsumerState<HomeView> {
           TextButton(
             onPressed: viewModel.onToggleExample,
             child: const Text('toggleExample'),
+          ),
+          TextButton(
+            onPressed: () => context.go(Routes.goal.path),
+            child: Text("온보딩"),
           ),
         ],
       ),

--- a/lib/ui/onboarding/onboarding_state.dart
+++ b/lib/ui/onboarding/onboarding_state.dart
@@ -14,9 +14,6 @@ class OnboardingState extends Equatable {
   final int selectedSuggestion;
   final List<GoalSuggestionModel> suggestions;
 
-  // final String goalNextButtonLabel;
-  // final bool isFinishedGoal;
-
   const OnboardingState({
     required this.getUserNameLoading,
     required this.getSuggestionsLoading,
@@ -24,8 +21,6 @@ class OnboardingState extends Equatable {
     required this.goalInputFieldText,
     required this.goalInputFieldErrorMsg,
     required this.suggestions,
-    // required this.goalNextButtonLabel,
-    // required this.isFinishedGoal,
     required this.selectedSuggestion,
   });
 
@@ -37,8 +32,6 @@ class OnboardingState extends Equatable {
         goalInputFieldErrorMsg: '',
         suggestions: <GoalSuggestionModel>[],
         selectedSuggestion: -1,
-        // goalNextButtonLabel: '다음',
-        // isFinishedGoal: false,
       );
 
   OnboardingState copyWith({
@@ -46,11 +39,9 @@ class OnboardingState extends Equatable {
     LoadingStatus? getSuggestionsLoading,
     String? userName,
     String? goalInputFieldText,
-    String? goalTextFieldErrorMsg,
+    String? goalInputFieldErrorMsg,
     int? selectedSuggestion,
     List<GoalSuggestionModel>? suggestions,
-    // String? goalNextButtonLabel,
-    // bool? isFinishedGoal,
   }) =>
       OnboardingState(
         getUserNameLoading: getUserNameLoading ?? this.getUserNameLoading,
@@ -60,10 +51,8 @@ class OnboardingState extends Equatable {
         goalInputFieldText: goalInputFieldText ?? this.goalInputFieldText,
         selectedSuggestion: selectedSuggestion ?? this.selectedSuggestion,
         goalInputFieldErrorMsg:
-            goalTextFieldErrorMsg ?? this.goalInputFieldErrorMsg,
+            goalInputFieldErrorMsg ?? this.goalInputFieldErrorMsg,
         suggestions: suggestions ?? this.suggestions,
-        // goalNextButtonLabel: goalNextButtonLabel ?? this.goalNextButtonLabel,
-        // isFinishedGoal: isFinishedGoal ?? this.isFinishedGoal,
       );
 
   @override

--- a/lib/ui/onboarding/onboarding_state.dart
+++ b/lib/ui/onboarding/onboarding_state.dart
@@ -1,0 +1,89 @@
+import 'package:equatable/equatable.dart';
+
+import '../../core/loading_status.dart';
+
+class OnboardingState extends Equatable {
+  final LoadingStatus getUserNameLoading;
+  final LoadingStatus getSuggestionsLoading;
+
+  final String userName;
+  final String goalInputFieldText;
+  final String goalInputFieldErrorMsg;
+
+  // text field enable, goal 결정, 선택된 목표 인덱스 저장
+  final int selectedSuggestion;
+  final List<GoalSuggestionModel> suggestions;
+
+  // final String goalNextButtonLabel;
+  // final bool isFinishedGoal;
+
+  const OnboardingState({
+    required this.getUserNameLoading,
+    required this.getSuggestionsLoading,
+    required this.userName,
+    required this.goalInputFieldText,
+    required this.goalInputFieldErrorMsg,
+    required this.suggestions,
+    // required this.goalNextButtonLabel,
+    // required this.isFinishedGoal,
+    required this.selectedSuggestion,
+  });
+
+  factory OnboardingState.init() => const OnboardingState(
+        getUserNameLoading: LoadingStatus.none,
+        getSuggestionsLoading: LoadingStatus.none,
+        userName: '',
+        goalInputFieldText: '',
+        goalInputFieldErrorMsg: '',
+        suggestions: <GoalSuggestionModel>[],
+        selectedSuggestion: -1,
+        // goalNextButtonLabel: '다음',
+        // isFinishedGoal: false,
+      );
+
+  OnboardingState copyWith({
+    LoadingStatus? getUserNameLoading,
+    LoadingStatus? getSuggestionsLoading,
+    String? userName,
+    String? goalInputFieldText,
+    String? goalTextFieldErrorMsg,
+    int? selectedSuggestion,
+    List<GoalSuggestionModel>? suggestions,
+    // String? goalNextButtonLabel,
+    // bool? isFinishedGoal,
+  }) =>
+      OnboardingState(
+        getUserNameLoading: getUserNameLoading ?? this.getUserNameLoading,
+        getSuggestionsLoading:
+            getSuggestionsLoading ?? this.getSuggestionsLoading,
+        userName: userName ?? this.userName,
+        goalInputFieldText: goalInputFieldText ?? this.goalInputFieldText,
+        selectedSuggestion: selectedSuggestion ?? this.selectedSuggestion,
+        goalInputFieldErrorMsg:
+            goalTextFieldErrorMsg ?? this.goalInputFieldErrorMsg,
+        suggestions: suggestions ?? this.suggestions,
+        // goalNextButtonLabel: goalNextButtonLabel ?? this.goalNextButtonLabel,
+        // isFinishedGoal: isFinishedGoal ?? this.isFinishedGoal,
+      );
+
+  @override
+  List<Object?> get props => <Object?>[
+        userName,
+        goalInputFieldText,
+        goalInputFieldErrorMsg,
+        selectedSuggestion,
+        suggestions,
+        // goalNextButtonLabel,
+        // isFinishedGoal,
+      ];
+}
+
+class GoalSuggestionModel {
+  final String suggestedGoal;
+  final String suggestedDuration;
+
+  const GoalSuggestionModel({
+    required this.suggestedGoal,
+    required this.suggestedDuration,
+  });
+}

--- a/lib/ui/onboarding/onboarding_view_model.dart
+++ b/lib/ui/onboarding/onboarding_view_model.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/loading_status.dart';
+import 'onboarding_state.dart';
+
+final AutoDisposeStateNotifierProvider<OnboardingViewModel, OnboardingState>
+    onboardingViewModelProvider =
+    StateNotifierProvider.autoDispose<OnboardingViewModel, OnboardingState>(
+  (StateNotifierProviderRef<OnboardingViewModel, OnboardingState> ref) =>
+      OnboardingViewModel(),
+);
+
+class OnboardingViewModel extends StateNotifier<OnboardingState> {
+  OnboardingViewModel() : super(OnboardingState.init());
+
+  void getUserName() {
+    state = state.copyWith(getUserNameLoading: LoadingStatus.loading);
+    state = state.copyWith(userName: '하수정');
+    state = state.copyWith(getUserNameLoading: LoadingStatus.success);
+  }
+
+  void getSuggestions() {
+    state = state.copyWith(getSuggestionsLoading: LoadingStatus.loading);
+    state = state.copyWith(suggestions: <GoalSuggestionModel>[
+      const GoalSuggestionModel(
+        suggestedGoal: '긍정적인 사람 되어보기',
+        suggestedDuration: '30일',
+      ),
+      const GoalSuggestionModel(
+        suggestedGoal: '긍정적인 사람 되어보기',
+        suggestedDuration: '30일',
+      ),
+      const GoalSuggestionModel(
+        suggestedGoal: '긍정적인 사람 되어보기',
+        suggestedDuration: '20일',
+      ),
+    ]);
+    state = state.copyWith(getSuggestionsLoading: LoadingStatus.success);
+  }
+
+  void onTapSuggestion({
+    required int index,
+  }) {
+    // 같은 것 선택 -> 취소 & text field 활성화
+    if (index == state.selectedSuggestion) {
+      state = state.copyWith(selectedSuggestion: -1);
+    }
+    // 새로운 것 선택 -> 선택 & text field 비활성화
+    else {
+      state = state.copyWith(selectedSuggestion: index);
+    }
+  }
+
+  void onChangedGoalTextField({
+    required String text,
+  }) {
+    state = state.copyWith(goalInputFieldText: text);
+    debugPrint('텍스트 변경: ${state.goalInputFieldText}');
+  }
+
+  void onTapNextButtonInGoal() {}
+
+  bool get enableGoalInputField => state.selectedSuggestion == -1;
+
+  bool get activateNextButtonInGoal =>
+      state.selectedSuggestion != -1 || state.goalInputFieldText.isNotEmpty;
+}

--- a/lib/ui/onboarding/views/onboarding_birth_view.dart
+++ b/lib/ui/onboarding/views/onboarding_birth_view.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class OnboardingFortuneView extends StatelessWidget {
+  const OnboardingFortuneView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/ui/onboarding/views/onboarding_duration_view.dart
+++ b/lib/ui/onboarding/views/onboarding_duration_view.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class OnboardingDurationView extends StatelessWidget {
+  const OnboardingDurationView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/ui/onboarding/views/onboarding_goal_view.dart
+++ b/lib/ui/onboarding/views/onboarding_goal_view.dart
@@ -40,6 +40,7 @@ class _OnboardingGoalViewState extends ConsumerState<OnboardingGoalView> {
       resizeToAvoidBottomInset: false,
       backgroundColor: LuckitColors.background,
       appBar: AppBar(
+        scrolledUnderElevation: 0.0,
         backgroundColor: LuckitColors.white,
         leading: IconButton(
           onPressed: () => context.go('/home'),
@@ -95,62 +96,63 @@ class _OnboardingGoalViewState extends ConsumerState<OnboardingGoalView> {
             ),
           ),
           Expanded(
-            child: SingleChildScrollView(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 24.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    const Padding(
-                      padding:
-                          EdgeInsets.only(left: 3.0, bottom: 10.0, top: 16.0),
-                      child: Text(
-                        '이루고 싶은 목표를 적어주세요',
-                        style: LuckitTypos.suitR16,
+            child: CustomScrollView(
+              slivers: <Widget>[
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                  sliver: SliverList(
+                    delegate: SliverChildListDelegate(<Widget>[
+                      const Padding(
+                        padding:
+                            EdgeInsets.only(left: 3.0, bottom: 10.0, top: 16.0),
+                        child: Text(
+                          '이루고 싶은 목표를 적어주세요',
+                          style: LuckitTypos.suitR16,
+                        ),
                       ),
-                    ),
-                    CustomTextField(
-                      fieldHeight: 52.0,
-                      hintText: '예) 매일 30분씩 어떤 공부든 하기',
-                      enabled: viewModel.enableGoalInputField,
-                      onChanged: (String text) =>
-                          viewModel.onChangedGoalTextField(text: text),
-                      fillColor: LuckitColors.white,
-                      enabledBorderColor: LuckitColors.gray40,
-                      focusedBorderColor: LuckitColors.main,
-                      textInputType: TextInputType.text,
-                      hintTextStyle: LuckitTypos.suitR12.copyWith(
-                        color: LuckitColors.gray40,
+                      CustomTextField(
+                        fieldHeight: 52.0,
+                        hintText: '예) 매일 30분씩 어떤 공부든 하기',
+                        enabled: viewModel.enableGoalInputField,
+                        onChanged: (String text) =>
+                            viewModel.onChangedGoalTextField(text: text),
+                        fillColor: LuckitColors.white,
+                        enabledBorderColor: LuckitColors.gray40,
+                        focusedBorderColor: LuckitColors.main,
+                        textInputType: TextInputType.text,
+                        hintTextStyle: LuckitTypos.suitR12.copyWith(
+                          color: LuckitColors.gray40,
+                        ),
                       ),
-                    ),
-                    const Padding(
-                      padding:
-                          EdgeInsets.only(left: 3.0, bottom: 10.0, top: 44.0),
-                      child: Text(
-                        '아직 고민 중이시라면, 이런 목표에 도전해보세요!',
-                        style: LuckitTypos.suitR16,
+                      const Padding(
+                        padding:
+                            EdgeInsets.only(left: 3.0, bottom: 10.0, top: 44.0),
+                        child: Text(
+                          '아직 고민 중이시라면, 이런 목표에 도전해보세요!',
+                          style: LuckitTypos.suitR16,
+                        ),
                       ),
-                    ),
-                    ListView.builder(
-                      shrinkWrap: true,
-                      itemCount: state.suggestions.length,
-                      itemBuilder: (BuildContext context, int index) {
-                        final GoalSuggestionModel model =
-                            state.suggestions[index];
+                      ...state.suggestions
+                          .asMap()
+                          .entries
+                          .map((MapEntry<int, GoalSuggestionModel> entry) {
+                        final int index = entry.key;
+                        final GoalSuggestionModel model = entry.value;
                         return GoalSuggestion(
                           index: index,
                           model: model,
                           onPressedCheck: () =>
                               viewModel.onTapSuggestion(index: index),
                         );
-                      },
-                    ),
-                  ],
+                      }),
+                    ]),
+                  ),
                 ),
-              ),
+              ],
             ),
           ),
           TextButton(
+            // viewModelX navigation으로 수정
             onPressed: viewModel.activateNextButtonInGoal
                 ? viewModel.onTapNextButtonInGoal
                 : null,
@@ -277,7 +279,8 @@ class GoalSuggestion extends ConsumerWidget {
                 child: Text(
                   '추천 기간 ${model.suggestedDuration}',
                   style: LuckitTypos.suitR10.copyWith(
-                    color: isChecked ? LuckitColors.gray60 : LuckitColors.gray40,
+                    color:
+                        isChecked ? LuckitColors.gray60 : LuckitColors.gray40,
                   ),
                 ),
               ),

--- a/lib/ui/onboarding/views/onboarding_goal_view.dart
+++ b/lib/ui/onboarding/views/onboarding_goal_view.dart
@@ -151,29 +151,10 @@ class _OnboardingGoalViewState extends ConsumerState<OnboardingGoalView> {
               ],
             ),
           ),
-          TextButton(
-            // viewModelX navigation으로 수정
-            onPressed: viewModel.activateNextButtonInGoal
-                ? viewModel.onTapNextButtonInGoal
-                : null,
-            style: TextButton.styleFrom(
-              minimumSize: Size(MediaQuery.of(context).size.width, 64.0),
-              backgroundColor: viewModel.activateNextButtonInGoal
-                  ? LuckitColors.main
-                  : LuckitColors.gray20,
-              padding: const EdgeInsets.symmetric(vertical: 16.0),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(0.0),
-              ),
-            ),
-            child: Text(
-              '기간 설정하기',
-              style: LuckitTypos.suitR20.copyWith(
-                color: viewModel.activateNextButtonInGoal
-                    ? LuckitColors.white
-                    : LuckitColors.gray80,
-              ),
-            ),
+          OnboardingBottomButton(
+            // onPressed는 router 추가 후 변경 예정
+            onPressed: () => viewModel.onTapNextButtonInGoal,
+            activated: viewModel.activateNextButtonInGoal,
           ),
         ],
       ),
@@ -181,41 +162,68 @@ class _OnboardingGoalViewState extends ConsumerState<OnboardingGoalView> {
   }
 }
 
-class CheckIcon extends ConsumerWidget {
-  final int index;
+class OnboardingBottomButton extends StatelessWidget {
   final VoidCallback onPressed;
+  final bool activated;
 
-  const CheckIcon({required this.index, required this.onPressed, super.key});
+  const OnboardingBottomButton({
+    required this.onPressed,
+    required this.activated,
+    super.key,
+  });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final OnboardingState state = ref.watch(onboardingViewModelProvider);
-    final bool isChecked = index == state.selectedSuggestion;
-
-    return IconButton(
-      onPressed: onPressed,
-      icon: Container(
-        // margin: const EdgeInsets.all(2.67),
-        width: 32,
-        height: 32,
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          color: isChecked ? LuckitColors.main : LuckitColors.gray20,
+  Widget build(BuildContext context) => TextButton(
+        // viewModelX navigation으로 수정
+        onPressed: activated ? onPressed : null,
+        style: TextButton.styleFrom(
+          minimumSize: Size(MediaQuery.of(context).size.width, 64.0),
+          backgroundColor: activated ? LuckitColors.main : LuckitColors.gray20,
+          padding: const EdgeInsets.symmetric(vertical: 16.0),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(0.0),
+          ),
         ),
-        child: Center(
-          child: SvgPicture.asset(
-            Assets.done,
-            width: 32,
-            height: 32,
-            colorFilter: const ColorFilter.mode(
-              Colors.white,
-              BlendMode.srcIn,
+        child: Text(
+          '기간 설정하기',
+          style: LuckitTypos.suitR20.copyWith(
+            color: activated ? LuckitColors.white : LuckitColors.gray80,
+          ),
+        ),
+      );
+}
+
+class CheckIcon extends StatelessWidget {
+  final bool isChecked;
+  final VoidCallback onPressed;
+
+  const CheckIcon(
+      {required this.isChecked, required this.onPressed, super.key});
+
+  @override
+  Widget build(BuildContext context) => IconButton(
+        onPressed: onPressed,
+        icon: Container(
+          // margin: const EdgeInsets.all(2.67),
+          width: 32,
+          height: 32,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: isChecked ? LuckitColors.main : LuckitColors.gray20,
+          ),
+          child: Center(
+            child: SvgPicture.asset(
+              Assets.done,
+              width: 32,
+              height: 32,
+              colorFilter: const ColorFilter.mode(
+                Colors.white,
+                BlendMode.srcIn,
+              ),
             ),
           ),
         ),
-      ),
-    );
-  }
+      );
 }
 
 class GoalSuggestion extends ConsumerWidget {
@@ -287,7 +295,7 @@ class GoalSuggestion extends ConsumerWidget {
             ],
           ),
           CheckIcon(
-            index: index,
+            isChecked: index == state.selectedSuggestion,
             onPressed: onPressedCheck,
           ),
         ],

--- a/lib/ui/onboarding/views/onboarding_goal_view.dart
+++ b/lib/ui/onboarding/views/onboarding_goal_view.dart
@@ -1,14 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../theme/luckit_colors.dart';
 import '../../../theme/luckit_typos.dart';
-import '../../common/consts/assets.dart';
 import '../../common/widgets/custom_text_field.dart';
 import '../onboarding_state.dart';
 import '../onboarding_view_model.dart';
+import '../widgets/check_icon_widget.dart';
+import '../widgets/onboarding_bottom_button.dart';
+import '../widgets/onboarding_layout.dart';
+import '../widgets/onboarding_top_widget.dart';
 
 Color shadowColor = const Color(0xffA6C1EE).withOpacity(0.15);
 
@@ -86,7 +88,7 @@ class _OnboardingGoalViewState extends ConsumerState<OnboardingGoalView> {
                       .map((MapEntry<int, GoalSuggestionModel> entry) {
                     final int index = entry.key;
                     final GoalSuggestionModel model = entry.value;
-                    return GoalSuggestion(
+                    return GoalSuggestionWidget(
                       index: index,
                       model: model,
                       onPressedCheck: () =>
@@ -107,172 +109,12 @@ class _OnboardingGoalViewState extends ConsumerState<OnboardingGoalView> {
   }
 }
 
-class OnboardingLayout extends StatelessWidget {
-  final VoidCallback onPressedBackButton;
-  final Widget topWidget;
-  final Widget content;
-  final Widget bottomButton;
-
-  const OnboardingLayout({
-    required this.onPressedBackButton,
-    required this.topWidget,
-    required this.content,
-    required this.bottomButton,
-    super.key,
-  });
-
-  @override
-  Widget build(BuildContext context) => Scaffold(
-      resizeToAvoidBottomInset: false,
-      backgroundColor: LuckitColors.background,
-      appBar: AppBar(
-        scrolledUnderElevation: 0.0,
-        backgroundColor: LuckitColors.white,
-        leading: IconButton(
-          onPressed: onPressedBackButton,
-          icon: SvgPicture.asset(
-            Assets.arrowLeft,
-          ),
-        ),
-      ),
-      body: Column(
-        children: <Widget>[topWidget, content, bottomButton],
-      ),
-    );
-}
-
-class OnboardingBottomButton extends StatelessWidget {
-  final VoidCallback onPressed;
-  final bool activated;
-
-  const OnboardingBottomButton({
-    required this.onPressed,
-    required this.activated,
-    super.key,
-  });
-
-  @override
-  Widget build(BuildContext context) => TextButton(
-        onPressed: activated ? onPressed : null,
-        style: TextButton.styleFrom(
-          minimumSize: Size(MediaQuery.of(context).size.width, 64.0),
-          backgroundColor: activated ? LuckitColors.main : LuckitColors.gray20,
-          padding: const EdgeInsets.symmetric(vertical: 16.0),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(0.0),
-          ),
-        ),
-        child: Text(
-          '기간 설정하기',
-          style: LuckitTypos.suitR20.copyWith(
-            color: activated ? LuckitColors.white : LuckitColors.gray80,
-          ),
-        ),
-      );
-}
-
-class CheckIcon extends StatelessWidget {
-  final bool isChecked;
-  final VoidCallback onPressed;
-
-  const CheckIcon(
-      {required this.isChecked, required this.onPressed, super.key});
-
-  @override
-  Widget build(BuildContext context) => IconButton(
-        onPressed: onPressed,
-        icon: Container(
-          // margin: const EdgeInsets.all(2.67),
-          width: 32,
-          height: 32,
-          decoration: BoxDecoration(
-            shape: BoxShape.circle,
-            color: isChecked ? LuckitColors.main : LuckitColors.gray20,
-          ),
-          child: Center(
-            child: SvgPicture.asset(
-              Assets.done,
-              width: 32,
-              height: 32,
-              colorFilter: const ColorFilter.mode(
-                Colors.white,
-                BlendMode.srcIn,
-              ),
-            ),
-          ),
-        ),
-      );
-}
-
-class OnboardingTopWidget extends StatelessWidget {
-  final String title;
-  final String text;
-  final String boldText;
-  final bool showShadow;
-
-  const OnboardingTopWidget({
-    required this.title,
-    required this.text,
-    required this.boldText,
-    this.showShadow = true,
-    super.key,
-  });
-
-  @override
-  Widget build(BuildContext context) => Container(
-        decoration: BoxDecoration(
-          color: LuckitColors.white,
-          borderRadius: const BorderRadius.only(
-            bottomLeft: Radius.circular(16.0),
-            bottomRight: Radius.circular(16.0),
-          ),
-          boxShadow: showShadow
-              ? <BoxShadow>[
-                  BoxShadow(
-                    blurRadius: 10.0,
-                    color: shadowColor,
-                  )
-                ]
-              : null,
-        ),
-        width: double.infinity,
-        padding: const EdgeInsets.only(
-            left: 24.0, right: 24.0, top: 12.0, bottom: 24.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Text(
-              title,
-              style: LuckitTypos.suitEB32.copyWith(
-                color: LuckitColors.main,
-              ),
-            ),
-            const SizedBox(height: 8.0),
-            Text.rich(
-              TextSpan(
-                children: <InlineSpan>[
-                  TextSpan(
-                    text: boldText,
-                    style: LuckitTypos.suitSB16,
-                  ),
-                  TextSpan(
-                    text: text,
-                    style: LuckitTypos.suitR16,
-                  ),
-                ],
-              ),
-            )
-          ],
-        ),
-      );
-}
-
-class GoalSuggestion extends ConsumerWidget {
+class GoalSuggestionWidget extends ConsumerWidget {
   final int index;
   final GoalSuggestionModel model;
   final VoidCallback onPressedCheck;
 
-  const GoalSuggestion({
+  const GoalSuggestionWidget({
     required this.index,
     required this.model,
     required this.onPressedCheck,
@@ -335,7 +177,7 @@ class GoalSuggestion extends ConsumerWidget {
               ),
             ],
           ),
-          CheckIcon(
+          CheckIconWidget(
             isChecked: index == state.selectedSuggestion,
             onPressed: onPressedCheck,
           ),

--- a/lib/ui/onboarding/views/onboarding_goal_view.dart
+++ b/lib/ui/onboarding/views/onboarding_goal_view.dart
@@ -1,0 +1,294 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../theme/luckit_colors.dart';
+import '../../../theme/luckit_typos.dart';
+import '../../common/consts/assets.dart';
+import '../../common/widgets/custom_text_field.dart';
+import '../onboarding_state.dart';
+import '../onboarding_view_model.dart';
+
+Color shadowColor = const Color(0xffA6C1EE).withOpacity(0.15);
+
+class OnboardingGoalView extends ConsumerStatefulWidget {
+  const OnboardingGoalView({super.key});
+
+  @override
+  ConsumerState<OnboardingGoalView> createState() => _OnboardingGoalViewState();
+}
+
+class _OnboardingGoalViewState extends ConsumerState<OnboardingGoalView> {
+  @override
+  void initState() {
+    super.initState();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(onboardingViewModelProvider.notifier).getUserName();
+      ref.read(onboardingViewModelProvider.notifier).getSuggestions();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final OnboardingViewModel viewModel =
+        ref.read(onboardingViewModelProvider.notifier);
+    final OnboardingState state = ref.watch(onboardingViewModelProvider);
+
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      backgroundColor: LuckitColors.background,
+      appBar: AppBar(
+        backgroundColor: LuckitColors.white,
+        leading: IconButton(
+          onPressed: () => context.go('/home'),
+          icon: SvgPicture.asset(
+            Assets.arrowLeft,
+          ),
+        ),
+      ),
+      body: Column(
+        children: <Widget>[
+          Container(
+            decoration: BoxDecoration(
+              color: LuckitColors.white,
+              borderRadius: const BorderRadius.only(
+                bottomLeft: Radius.circular(16.0),
+                bottomRight: Radius.circular(16.0),
+              ),
+              boxShadow: <BoxShadow>[
+                BoxShadow(
+                  blurRadius: 10.0,
+                  color: shadowColor,
+                )
+              ],
+            ),
+            width: double.infinity,
+            padding: const EdgeInsets.only(
+                left: 24.0, right: 24.0, top: 12.0, bottom: 24.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  '이루고 싶은 목표는\n무엇인가요?',
+                  style: LuckitTypos.suitEB32.copyWith(
+                    color: LuckitColors.main,
+                  ),
+                ),
+                const SizedBox(height: 8.0),
+                Text.rich(
+                  TextSpan(
+                    children: <InlineSpan>[
+                      TextSpan(
+                        text: state.userName,
+                        style: LuckitTypos.suitSB16,
+                      ),
+                      const TextSpan(
+                        text: '님이 목표에 한 발짝 더\n가까워질 수 있도록 도와드릴게요!',
+                        style: LuckitTypos.suitR16,
+                      ),
+                    ],
+                  ),
+                )
+              ],
+            ),
+          ),
+          Expanded(
+            child: SingleChildScrollView(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    const Padding(
+                      padding:
+                          EdgeInsets.only(left: 3.0, bottom: 10.0, top: 16.0),
+                      child: Text(
+                        '이루고 싶은 목표를 적어주세요',
+                        style: LuckitTypos.suitR16,
+                      ),
+                    ),
+                    CustomTextField(
+                      fieldHeight: 52.0,
+                      hintText: '예) 매일 30분씩 어떤 공부든 하기',
+                      enabled: viewModel.enableGoalInputField,
+                      onChanged: (String text) =>
+                          viewModel.onChangedGoalTextField(text: text),
+                      fillColor: LuckitColors.white,
+                      enabledBorderColor: LuckitColors.gray40,
+                      focusedBorderColor: LuckitColors.main,
+                      textInputType: TextInputType.text,
+                      hintTextStyle: LuckitTypos.suitR12.copyWith(
+                        color: LuckitColors.gray40,
+                      ),
+                    ),
+                    const Padding(
+                      padding:
+                          EdgeInsets.only(left: 3.0, bottom: 10.0, top: 44.0),
+                      child: Text(
+                        '아직 고민 중이시라면, 이런 목표에 도전해보세요!',
+                        style: LuckitTypos.suitR16,
+                      ),
+                    ),
+                    ListView.builder(
+                      shrinkWrap: true,
+                      itemCount: state.suggestions.length,
+                      itemBuilder: (BuildContext context, int index) {
+                        final GoalSuggestionModel model =
+                            state.suggestions[index];
+                        return GoalSuggestion(
+                          index: index,
+                          model: model,
+                          onPressedCheck: () =>
+                              viewModel.onTapSuggestion(index: index),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          TextButton(
+            onPressed: viewModel.activateNextButtonInGoal
+                ? viewModel.onTapNextButtonInGoal
+                : null,
+            style: TextButton.styleFrom(
+              minimumSize: Size(MediaQuery.of(context).size.width, 64.0),
+              backgroundColor: viewModel.activateNextButtonInGoal
+                  ? LuckitColors.main
+                  : LuckitColors.gray20,
+              padding: const EdgeInsets.symmetric(vertical: 16.0),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(0.0),
+              ),
+            ),
+            child: Text(
+              '기간 설정하기',
+              style: LuckitTypos.suitR20.copyWith(
+                color: viewModel.activateNextButtonInGoal
+                    ? LuckitColors.white
+                    : LuckitColors.gray80,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class CheckIcon extends ConsumerWidget {
+  final int index;
+  final VoidCallback onPressed;
+
+  const CheckIcon({required this.index, required this.onPressed, super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final OnboardingState state = ref.watch(onboardingViewModelProvider);
+    final bool isChecked = index == state.selectedSuggestion;
+
+    return IconButton(
+      onPressed: onPressed,
+      icon: Container(
+        // margin: const EdgeInsets.all(2.67),
+        width: 32,
+        height: 32,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: isChecked ? LuckitColors.main : LuckitColors.gray20,
+        ),
+        child: Center(
+          child: SvgPicture.asset(
+            Assets.done,
+            width: 32,
+            height: 32,
+            colorFilter: const ColorFilter.mode(
+              Colors.white,
+              BlendMode.srcIn,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class GoalSuggestion extends ConsumerWidget {
+  final int index;
+  final GoalSuggestionModel model;
+  final VoidCallback onPressedCheck;
+
+  const GoalSuggestion({
+    required this.index,
+    required this.model,
+    required this.onPressedCheck,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final OnboardingState state = ref.watch(onboardingViewModelProvider);
+    final bool isChecked = state.selectedSuggestion == index;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12.0),
+      padding: const EdgeInsets.only(
+          left: 12.0, right: 12.0, top: 14.0, bottom: 8.0),
+      width: double.infinity,
+      decoration: BoxDecoration(
+        borderRadius: const BorderRadius.all(
+          Radius.circular(8.0),
+        ),
+        color: LuckitColors.white,
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            blurRadius: 10.0,
+            color: shadowColor,
+          )
+        ],
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: <Widget>[
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                model.suggestedGoal,
+                style: LuckitTypos.suitSB16.copyWith(
+                  color: isChecked ? LuckitColors.main : LuckitColors.gray40,
+                ),
+              ),
+              const SizedBox(height: 8.0),
+              Container(
+                margin: const EdgeInsets.only(top: 8.0),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 8.0,
+                  vertical: 4.0,
+                ),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(12.0),
+                  color: LuckitColors.gray10,
+                ),
+                child: Text(
+                  '추천 기간 ${model.suggestedDuration}',
+                  style: LuckitTypos.suitR10.copyWith(
+                    color: isChecked ? LuckitColors.gray60 : LuckitColors.gray40,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          CheckIcon(
+            index: index,
+            onPressed: onPressedCheck,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/onboarding/views/onboarding_goal_view.dart
+++ b/lib/ui/onboarding/views/onboarding_goal_view.dart
@@ -36,130 +36,109 @@ class _OnboardingGoalViewState extends ConsumerState<OnboardingGoalView> {
         ref.read(onboardingViewModelProvider.notifier);
     final OnboardingState state = ref.watch(onboardingViewModelProvider);
 
-    return Scaffold(
+    return OnboardingLayout(
+      onPressedBackButton: () => context.go('/home'),
+      topWidget: OnboardingTopWidget(
+        title: '이루고 싶은 목표는\n무엇인가요?',
+        text: '님이 목표에 한 발짝 더\n가까워질 수 있도록 도와드릴게요!',
+        boldText: state.userName,
+      ),
+      content: Expanded(
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(horizontal: 24.0),
+              sliver: SliverList(
+                delegate: SliverChildListDelegate(<Widget>[
+                  const Padding(
+                    padding:
+                        EdgeInsets.only(left: 3.0, bottom: 10.0, top: 16.0),
+                    child: Text(
+                      '이루고 싶은 목표를 적어주세요',
+                      style: LuckitTypos.suitR16,
+                    ),
+                  ),
+                  CustomTextField(
+                    fieldHeight: 52.0,
+                    hintText: '예) 매일 30분씩 어떤 공부든 하기',
+                    enabled: viewModel.enableGoalInputField,
+                    onChanged: (String text) =>
+                        viewModel.onChangedGoalTextField(text: text),
+                    fillColor: LuckitColors.white,
+                    enabledBorderColor: LuckitColors.gray40,
+                    focusedBorderColor: LuckitColors.main,
+                    textInputType: TextInputType.text,
+                    hintTextStyle: LuckitTypos.suitR12.copyWith(
+                      color: LuckitColors.gray40,
+                    ),
+                  ),
+                  const Padding(
+                    padding:
+                        EdgeInsets.only(left: 3.0, bottom: 10.0, top: 44.0),
+                    child: Text(
+                      '아직 고민 중이시라면, 이런 목표에 도전해보세요!',
+                      style: LuckitTypos.suitR16,
+                    ),
+                  ),
+                  ...state.suggestions
+                      .asMap()
+                      .entries
+                      .map((MapEntry<int, GoalSuggestionModel> entry) {
+                    final int index = entry.key;
+                    final GoalSuggestionModel model = entry.value;
+                    return GoalSuggestion(
+                      index: index,
+                      model: model,
+                      onPressedCheck: () =>
+                          viewModel.onTapSuggestion(index: index),
+                    );
+                  }),
+                ]),
+              ),
+            ),
+          ],
+        ),
+      ),
+      bottomButton: OnboardingBottomButton(
+        onPressed: () => viewModel.onTapNextButtonInGoal,
+        activated: viewModel.activateNextButtonInGoal,
+      ),
+    );
+  }
+}
+
+class OnboardingLayout extends StatelessWidget {
+  final VoidCallback onPressedBackButton;
+  final Widget topWidget;
+  final Widget content;
+  final Widget bottomButton;
+
+  const OnboardingLayout({
+    required this.onPressedBackButton,
+    required this.topWidget,
+    required this.content,
+    required this.bottomButton,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
       resizeToAvoidBottomInset: false,
       backgroundColor: LuckitColors.background,
       appBar: AppBar(
         scrolledUnderElevation: 0.0,
         backgroundColor: LuckitColors.white,
         leading: IconButton(
-          onPressed: () => context.go('/home'),
+          onPressed: onPressedBackButton,
           icon: SvgPicture.asset(
             Assets.arrowLeft,
           ),
         ),
       ),
       body: Column(
-        children: <Widget>[
-          Container(
-            decoration: BoxDecoration(
-              color: LuckitColors.white,
-              borderRadius: const BorderRadius.only(
-                bottomLeft: Radius.circular(16.0),
-                bottomRight: Radius.circular(16.0),
-              ),
-              boxShadow: <BoxShadow>[
-                BoxShadow(
-                  blurRadius: 10.0,
-                  color: shadowColor,
-                )
-              ],
-            ),
-            width: double.infinity,
-            padding: const EdgeInsets.only(
-                left: 24.0, right: 24.0, top: 12.0, bottom: 24.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text(
-                  '이루고 싶은 목표는\n무엇인가요?',
-                  style: LuckitTypos.suitEB32.copyWith(
-                    color: LuckitColors.main,
-                  ),
-                ),
-                const SizedBox(height: 8.0),
-                Text.rich(
-                  TextSpan(
-                    children: <InlineSpan>[
-                      TextSpan(
-                        text: state.userName,
-                        style: LuckitTypos.suitSB16,
-                      ),
-                      const TextSpan(
-                        text: '님이 목표에 한 발짝 더\n가까워질 수 있도록 도와드릴게요!',
-                        style: LuckitTypos.suitR16,
-                      ),
-                    ],
-                  ),
-                )
-              ],
-            ),
-          ),
-          Expanded(
-            child: CustomScrollView(
-              slivers: <Widget>[
-                SliverPadding(
-                  padding: const EdgeInsets.symmetric(horizontal: 24.0),
-                  sliver: SliverList(
-                    delegate: SliverChildListDelegate(<Widget>[
-                      const Padding(
-                        padding:
-                            EdgeInsets.only(left: 3.0, bottom: 10.0, top: 16.0),
-                        child: Text(
-                          '이루고 싶은 목표를 적어주세요',
-                          style: LuckitTypos.suitR16,
-                        ),
-                      ),
-                      CustomTextField(
-                        fieldHeight: 52.0,
-                        hintText: '예) 매일 30분씩 어떤 공부든 하기',
-                        enabled: viewModel.enableGoalInputField,
-                        onChanged: (String text) =>
-                            viewModel.onChangedGoalTextField(text: text),
-                        fillColor: LuckitColors.white,
-                        enabledBorderColor: LuckitColors.gray40,
-                        focusedBorderColor: LuckitColors.main,
-                        textInputType: TextInputType.text,
-                        hintTextStyle: LuckitTypos.suitR12.copyWith(
-                          color: LuckitColors.gray40,
-                        ),
-                      ),
-                      const Padding(
-                        padding:
-                            EdgeInsets.only(left: 3.0, bottom: 10.0, top: 44.0),
-                        child: Text(
-                          '아직 고민 중이시라면, 이런 목표에 도전해보세요!',
-                          style: LuckitTypos.suitR16,
-                        ),
-                      ),
-                      ...state.suggestions
-                          .asMap()
-                          .entries
-                          .map((MapEntry<int, GoalSuggestionModel> entry) {
-                        final int index = entry.key;
-                        final GoalSuggestionModel model = entry.value;
-                        return GoalSuggestion(
-                          index: index,
-                          model: model,
-                          onPressedCheck: () =>
-                              viewModel.onTapSuggestion(index: index),
-                        );
-                      }),
-                    ]),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          OnboardingBottomButton(
-            // onPressed는 router 추가 후 변경 예정
-            onPressed: () => viewModel.onTapNextButtonInGoal,
-            activated: viewModel.activateNextButtonInGoal,
-          ),
-        ],
+        children: <Widget>[topWidget, content, bottomButton],
       ),
     );
-  }
 }
 
 class OnboardingBottomButton extends StatelessWidget {
@@ -174,7 +153,6 @@ class OnboardingBottomButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => TextButton(
-        // viewModelX navigation으로 수정
         onPressed: activated ? onPressed : null,
         style: TextButton.styleFrom(
           minimumSize: Size(MediaQuery.of(context).size.width, 64.0),
@@ -222,6 +200,69 @@ class CheckIcon extends StatelessWidget {
               ),
             ),
           ),
+        ),
+      );
+}
+
+class OnboardingTopWidget extends StatelessWidget {
+  final String title;
+  final String text;
+  final String boldText;
+  final bool showShadow;
+
+  const OnboardingTopWidget({
+    required this.title,
+    required this.text,
+    required this.boldText,
+    this.showShadow = true,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) => Container(
+        decoration: BoxDecoration(
+          color: LuckitColors.white,
+          borderRadius: const BorderRadius.only(
+            bottomLeft: Radius.circular(16.0),
+            bottomRight: Radius.circular(16.0),
+          ),
+          boxShadow: showShadow
+              ? <BoxShadow>[
+                  BoxShadow(
+                    blurRadius: 10.0,
+                    color: shadowColor,
+                  )
+                ]
+              : null,
+        ),
+        width: double.infinity,
+        padding: const EdgeInsets.only(
+            left: 24.0, right: 24.0, top: 12.0, bottom: 24.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              title,
+              style: LuckitTypos.suitEB32.copyWith(
+                color: LuckitColors.main,
+              ),
+            ),
+            const SizedBox(height: 8.0),
+            Text.rich(
+              TextSpan(
+                children: <InlineSpan>[
+                  TextSpan(
+                    text: boldText,
+                    style: LuckitTypos.suitSB16,
+                  ),
+                  TextSpan(
+                    text: text,
+                    style: LuckitTypos.suitR16,
+                  ),
+                ],
+              ),
+            )
+          ],
         ),
       );
 }

--- a/lib/ui/onboarding/widgets/check_icon_widget.dart
+++ b/lib/ui/onboarding/widgets/check_icon_widget.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+import '../../../theme/luckit_colors.dart';
+import '../../common/consts/assets.dart';
+
+class CheckIconWidget extends StatelessWidget {
+  final bool isChecked;
+  final VoidCallback onPressed;
+
+  const CheckIconWidget(
+      {required this.isChecked, required this.onPressed, super.key});
+
+  @override
+  Widget build(BuildContext context) => IconButton(
+    onPressed: onPressed,
+    icon: Container(
+      // margin: const EdgeInsets.all(2.67),
+      width: 32,
+      height: 32,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: isChecked ? LuckitColors.main : LuckitColors.gray20,
+      ),
+      child: Center(
+        child: SvgPicture.asset(
+          Assets.done,
+          width: 32,
+          height: 32,
+          colorFilter: const ColorFilter.mode(
+            Colors.white,
+            BlendMode.srcIn,
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/ui/onboarding/widgets/onboarding_bottom_button.dart
+++ b/lib/ui/onboarding/widgets/onboarding_bottom_button.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import '../../../theme/luckit_colors.dart';
+import '../../../theme/luckit_typos.dart';
+
+class OnboardingBottomButton extends StatelessWidget {
+  final VoidCallback onPressed;
+  final bool activated;
+
+  const OnboardingBottomButton({
+    required this.onPressed,
+    required this.activated,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) => TextButton(
+    onPressed: activated ? onPressed : null,
+    style: TextButton.styleFrom(
+      minimumSize: Size(MediaQuery.of(context).size.width, 64.0),
+      backgroundColor: activated ? LuckitColors.main : LuckitColors.gray20,
+      padding: const EdgeInsets.symmetric(vertical: 16.0),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(0.0),
+      ),
+    ),
+    child: Text(
+      '기간 설정하기',
+      style: LuckitTypos.suitR20.copyWith(
+        color: activated ? LuckitColors.white : LuckitColors.gray80,
+      ),
+    ),
+  );
+}

--- a/lib/ui/onboarding/widgets/onboarding_layout.dart
+++ b/lib/ui/onboarding/widgets/onboarding_layout.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+import '../../../theme/luckit_colors.dart';
+import '../../common/consts/assets.dart';
+
+class OnboardingLayout extends StatelessWidget {
+  final VoidCallback onPressedBackButton;
+  final Widget topWidget;
+  final Widget content;
+  final Widget bottomButton;
+
+  const OnboardingLayout({
+    required this.onPressedBackButton,
+    required this.topWidget,
+    required this.content,
+    required this.bottomButton,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+    resizeToAvoidBottomInset: false,
+    backgroundColor: LuckitColors.background,
+    appBar: AppBar(
+      scrolledUnderElevation: 0.0,
+      backgroundColor: LuckitColors.white,
+      leading: IconButton(
+        onPressed: onPressedBackButton,
+        icon: SvgPicture.asset(
+          Assets.arrowLeft,
+        ),
+      ),
+    ),
+    body: Column(
+      children: <Widget>[topWidget, content, bottomButton],
+    ),
+  );
+}

--- a/lib/ui/onboarding/widgets/onboarding_top_widget.dart
+++ b/lib/ui/onboarding/widgets/onboarding_top_widget.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+import '../../../theme/luckit_colors.dart';
+import '../../../theme/luckit_typos.dart';
+import '../views/onboarding_goal_view.dart';
+
+class OnboardingTopWidget extends StatelessWidget {
+  final String title;
+  final String text;
+  final String boldText;
+  final bool showShadow;
+
+  const OnboardingTopWidget({
+    required this.title,
+    required this.text,
+    required this.boldText,
+    this.showShadow = true,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) => Container(
+    decoration: BoxDecoration(
+      color: LuckitColors.white,
+      borderRadius: const BorderRadius.only(
+        bottomLeft: Radius.circular(16.0),
+        bottomRight: Radius.circular(16.0),
+      ),
+      boxShadow: showShadow
+          ? <BoxShadow>[
+        BoxShadow(
+          blurRadius: 10.0,
+          color: shadowColor,
+        )
+      ]
+          : null,
+    ),
+    width: double.infinity,
+    padding: const EdgeInsets.only(
+        left: 24.0, right: 24.0, top: 12.0, bottom: 24.0),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          title,
+          style: LuckitTypos.suitEB32.copyWith(
+            color: LuckitColors.main,
+          ),
+        ),
+        const SizedBox(height: 8.0),
+        Text.rich(
+          TextSpan(
+            children: <InlineSpan>[
+              TextSpan(
+                text: boldText,
+                style: LuckitTypos.suitSB16,
+              ),
+              TextSpan(
+                text: text,
+                style: LuckitTypos.suitR16,
+              ),
+            ],
+          ),
+        )
+      ],
+    ),
+  );
+}


### PR DESCRIPTION
## 이슈
- #3 

## 변경사항
> 리뷰 늦어지는 김에 추가작업 했습니다!

- 온보딩 목표 입력 화면 만들었습니다
   - 기간 설정/사주 입력 부분은 아직이지만 일단 올립니다
- 디테일 커밋 추가합니다
    - 작은 화면을 위해 스크롤 넣었습니다 (세로 길이 800 미만부터 문제가 생기는 듯!)
    - 스크롤 시 앱바 색이 변하지 않도록 수정
- 의존성 분리 커밋 추가합니다
   - 위젯의 state와 callback은 최대한 파라미터로 전달하게 만들었습니다

## 질문
- 온보딩 뷰가 세 개(목표, 기간, 사주 입력)여서 온보딩 레이아웃을 두었는데, 이렇게 Scaffold까지 포함시켜서 레이아웃 만들기도 하나요? 
- 스크롤 넣을 때 하단 버튼은 고정되게 하면 되겠죠?
![image](https://github.com/user-attachments/assets/e49dd62c-d870-40fc-b567-3e4d8ecfc1d7)

## 제안
- 피그마대로 추천 기간 아래 여백을 8로 두었는데, 조금 늘릴까요? 좀 좁은 거 같아서요
![image](https://github.com/user-attachments/assets/65ace75b-e9e1-428f-9157-50e7e8a2fda5)

## 메모
`GoalSuggestionModel`은 추후 유스케이스 작업 단계에서 유스케이스 모델로 옮기면 될 것 같습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new onboarding flow with dedicated views for goal setting, duration, and user input.
	- Added customizable text fields for user input during onboarding.
	- Implemented a navigation button on the home view to access the onboarding process.
	- Enhanced state management for onboarding using Riverpod.
	- Added a new route for the onboarding goal view.
	- Introduced new widgets for onboarding layout and user interaction, including `CheckIconWidget` and `OnboardingBottomButton`.

- **Bug Fixes**
	- Improved error handling and user input validation in onboarding widgets.

- **Documentation**
	- Updated documentation to reflect new onboarding features and navigation changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->